### PR TITLE
Use VPC IPs for k8s worker upstream

### DIFF
--- a/sites-enabled/upstreams.conf
+++ b/sites-enabled/upstreams.conf
@@ -1,6 +1,6 @@
 upstream k8s_production {
-    server 138.197.146.243:30000;
-    server 68.183.194.110:30000;
+    server 10.118.0.3:30000;  # k8s-worker01 VPC
+    server 10.118.0.7:30000;  # k8s-worker02 VPC
 }
 
 upstream vault_production {


### PR DESCRIPTION
## Summary
- Route traffic to k8s workers via VPC instead of public IPs
- Keeps traffic internal to DigitalOcean network (faster, more secure)
- Works with the new firewall rules in osuAkatsuki/k8s-infra#22

## VPC IPs
| Server | Public IP | VPC IP |
|--------|-----------|--------|
| k8s-worker01 | 138.197.146.243 | 10.118.0.3 |
| k8s-worker02 | 68.183.194.110 | 10.118.0.7 |

## Test plan
- [ ] Deploy to mysql-master01
- [ ] Verify site loads correctly
- [ ] Check nginx logs for any connection errors

🤖 Generated with [Claude Code](https://claude.ai/code)