### PR TITLE
Improve gzip compression configuration

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -60,6 +60,13 @@ http {
 
         # compression settings
         gzip on;
+        gzip_vary on;
+        gzip_proxied any;
+        gzip_comp_level 6;
+        gzip_types text/plain text/css text/xml text/javascript
+                   application/json application/javascript application/xml
+                   application/rss+xml application/atom+xml
+                   image/svg+xml font/ttf font/otf;
 
         # deny any connections without a host header
         server {


### PR DESCRIPTION
## Summary
- Add `gzip_vary on` for proper caching with proxies
- Add `gzip_proxied any` to compress proxied responses
- Set `gzip_comp_level 6` for good compression/speed balance
- Configure `gzip_types` for CSS, JS, JSON, SVG, and fonts

Previously only had bare `gzip on;` which uses defaults (level 1, limited types). This should reduce transfer sizes for text assets by 60-80%.

## Test plan
- [ ] Deploy to staging and verify gzip is being applied via response headers
- [ ] Check `Content-Encoding: gzip` on CSS/JS responses
- [ ] Verify `Vary: Accept-Encoding` header is present

🤖 Generated with [Claude Code](https://claude.com/claude-code)