### PR TITLE
Fix phpMyAdmin routing issues

### DIFF
--- a/sites-enabled/admin_panel.conf
+++ b/sites-enabled/admin_panel.conf
@@ -2,13 +2,22 @@ server {
     listen 80;
     server_name old.akatsuki.gg old.akatsuki.pw;
 
-    location /phpmyadmin {
+    # Redirect /phpmyadmin to /phpmyadmin/
+    location = /phpmyadmin {
+        return 301 /phpmyadmin/;
+    }
+
+    location /phpmyadmin/ {
         proxy_set_header X-Real-IP $http_CF_Connecting_IP;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header Host $http_host;
 
-        # TODO: fix redirects sending to old.akatsuki.gg/
+        # Strip /phpmyadmin prefix before passing to backend
         rewrite ^/phpmyadmin(/.*)$ $1 break;
+
+        # Rewrite redirects from backend to include /phpmyadmin prefix
+        proxy_redirect / /phpmyadmin/;
+
         proxy_pass http://phpmyadmin;
     }
 


### PR DESCRIPTION
## Summary
- Add exact match redirect for `/phpmyadmin` to `/phpmyadmin/` (fixes 404 on path without trailing slash)
- Add `proxy_redirect` directive to rewrite backend redirects with `/phpmyadmin` prefix (fixes post-login redirect to wrong URL)

## Test plan
- [ ] Access `https://old.akatsuki.gg/phpmyadmin` (without trailing slash) - should redirect to `/phpmyadmin/`
- [ ] Login to phpMyAdmin - should stay within `/phpmyadmin/` path after login

🤖 Generated with [Claude Code](https://claude.com/claude-code)