### PR TITLE
Remove proxy_redirect to avoid double prefix

### DIFF
--- a/sites-enabled/admin_panel.conf
+++ b/sites-enabled/admin_panel.conf
@@ -15,9 +15,6 @@ server {
         # Strip /phpmyadmin prefix before passing to backend
         rewrite ^/phpmyadmin(/.*)$ $1 break;
 
-        # Rewrite redirects from backend to include /phpmyadmin prefix
-        proxy_redirect / /phpmyadmin/;
-
         proxy_pass http://phpmyadmin;
     }
 


### PR DESCRIPTION
## Summary
Removes `proxy_redirect / /phpmyadmin/;` which was causing double prefixes (`/phpmyadmin/phpmyadmin/`) on login/logout redirects.

## Details
The phpMyAdmin deployment has `PMA_ABSOLUTE_URI=https://old.akatsuki.gg/phpmyadmin/` which tells phpMyAdmin its base URL. This means phpMyAdmin already generates correct redirects like `Location: /phpmyadmin/index.php`.

The nginx `proxy_redirect / /phpmyadmin/;` was then transforming those to `/phpmyadmin/phpmyadmin/index.php`, causing the double prefix issue.

## Test plan
- [ ] Login to phpMyAdmin - should redirect to `/phpmyadmin/` not `/phpmyadmin/phpmyadmin/`
- [ ] Logout from phpMyAdmin - should redirect correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)